### PR TITLE
 Consistently set archived file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ IMPROVEMENTS:
 
 * The provider is now compatible with Terraform v0.12, while retaining compatibility with prior versions.
 
+BUG FIXES:
+
+* Fix file permissions affecting zip contents and causing spurious diffs ([#34](https://github.com/terraform-providers/terraform-provider-archive/issues/34))
+
 ## 1.1.0 (July 30, 2018)
 
 ENHANCEMENTS:

--- a/archive/zip_archiver.go
+++ b/archive/zip_archiver.go
@@ -61,6 +61,7 @@ func (a *ZipArchiver) ArchiveFile(infilename string) error {
 	fh.Method = zip.Deflate
 	// fh.Modified alone isn't enough when using a zero value
 	fh.SetModTime(time.Time{})
+	fh.SetMode(0444)
 
 	f, err := a.writer.CreateHeader(fh)
 	if err != nil {

--- a/archive/zip_archiver.go
+++ b/archive/zip_archiver.go
@@ -61,7 +61,18 @@ func (a *ZipArchiver) ArchiveFile(infilename string) error {
 	fh.Method = zip.Deflate
 	// fh.Modified alone isn't enough when using a zero value
 	fh.SetModTime(time.Time{})
-	fh.SetMode(0444)
+
+	// check if file is executable
+	info, err := os.Stat(infilename)
+	if err != nil {
+		return err
+	}
+	mode := info.Mode().Perm()
+	if mode&0100 == 0100 {
+		fh.SetMode(0555)
+	} else {
+		fh.SetMode(0444)
+	}
 
 	f, err := a.writer.CreateHeader(fh)
 	if err != nil {

--- a/archive/zip_archiver_test.go
+++ b/archive/zip_archiver_test.go
@@ -76,6 +76,48 @@ func TestZipArchiver_FilePermissionsModified(t *testing.T) {
 	}
 }
 
+func TestZipArchiver_FileExecutablePermissionsModified(t *testing.T) {
+	var (
+		zipFilePath = filepath.FromSlash("archive-file.zip")
+		toZipPath   = filepath.FromSlash("./test-fixtures/test-file.txt")
+	)
+
+	var zip = func() {
+		archiver := NewZipArchiver(zipFilePath)
+		if err := archiver.ArchiveFile(toZipPath); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	}
+
+	//set initial file permissions
+	if err := os.Chmod(toZipPath, 0700); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	zip()
+
+	expectedContents, err := ioutil.ReadFile(zipFilePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	//make file executable
+	if err := os.Chmod(toZipPath, 0644); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	zip()
+
+	actualContents, err := ioutil.ReadFile(zipFilePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if bytes.Equal(expectedContents, actualContents) {
+		t.Fatalf("zip contents match, potentially a permission issue")
+	}
+}
+
 func TestZipArchiver_FileTimeModified(t *testing.T) {
 	var (
 		zipFilePath = filepath.FromSlash("archive-file.zip")


### PR DESCRIPTION
This pull request consistently sets archived file permissions to either `0444` or `0555` depending on whether or not the file is executable. It's likely directories may also need to be consistently set to `0555` or `0777` depending on if they need to be writable or not (or perhaps they can simply be excluded from the archive). I can make that change if desired, or we can leave it for a separate PR.

This fix should help to address https://github.com/terraform-providers/terraform-provider-archive/issues/34.