### PR TITLE
Support glob matching for zip excludes

### DIFF
--- a/archive/zip_archiver.go
+++ b/archive/zip_archiver.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"time"
+
+	"github.com/bmatcuk/doublestar"
 )
 
 type ZipArchiver struct {
@@ -71,17 +73,33 @@ func (a *ZipArchiver) ArchiveFile(infilename string) error {
 	return err
 }
 
-func checkMatch(fileName string, excludes []string) (value bool) {
+func checkMatch(fileName, indirname string, excludes []string) (value bool, err error) {
 	for _, exclude := range excludes {
-		if exclude == "" {
-			continue
+		globExcludes, err := doublestar.Glob(filepath.Join(indirname, exclude))
+		if err != nil {
+			return false, fmt.Errorf("error computing glob paths: %s", err)
 		}
 
-		if exclude == fileName {
-			return true
+		for _, globExclude := range globExcludes {
+			relExclude, err := filepath.Rel(indirname, globExclude)
+			if err != nil {
+				return false, fmt.Errorf("error relativizing exclude for archival: %s", err)
+			}
+
+			if err != nil {
+				return false, err
+			}
+
+			if exclude == "" {
+				continue
+			}
+
+			if relExclude == fileName {
+				return true, nil
+			}
 		}
 	}
-	return false
+	return false, nil
 }
 
 func (a *ZipArchiver) ArchiveDir(indirname string, excludes []string) error {
@@ -106,7 +124,10 @@ func (a *ZipArchiver) ArchiveDir(indirname string, excludes []string) error {
 			return fmt.Errorf("error relativizing file for archival: %s", err)
 		}
 
-		isMatch := checkMatch(relname, excludes)
+		isMatch, err := checkMatch(relname, indirname, excludes)
+		if err != nil {
+			return fmt.Errorf("error parsing glob: %s", err)
+		}
 
 		if info.IsDir() {
 			if isMatch {

--- a/archive/zip_archiver_test.go
+++ b/archive/zip_archiver_test.go
@@ -112,6 +112,21 @@ func TestZipArchiver_Dir_Exclude_With_Directory(t *testing.T) {
 	})
 }
 
+func TestZipArchiver_Dir_Exclude_With_Glob(t *testing.T) {
+	zipfilepath := "archive-dir.zip"
+	archiver := NewZipArchiver(zipfilepath)
+	if err := archiver.ArchiveDir("./test-fixtures/", []string{"**/file2.txt", "test-dir2/*1.txt"}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureContents(t, zipfilepath, map[string][]byte{
+		"test-dir/file1.txt":  []byte("This is file 1"),
+		"test-dir/file3.txt":  []byte("This is file 3"),
+		"test-dir2/file3.txt": []byte("This is file 3"),
+		"test-file.txt":       []byte("This is test content"),
+	})
+}
+
 func TestZipArchiver_Multiple(t *testing.T) {
 	zipfilepath := "archive-content.zip"
 	content := map[string][]byte{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/terraform-providers/terraform-provider-archive
 
 require (
+	github.com/bmatcuk/doublestar v1.2.2
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1U
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bmatcuk/doublestar v1.2.2 h1:oC24CykoSAB8zd7XgruHo33E0cHJf/WhQA/7BeXj+x0=
+github.com/bmatcuk/doublestar v1.2.2/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=


### PR DESCRIPTION
Add support for excluding files and directories using a glob expression
supplied to `excludes`. In particular, `*` matches any character (except
the directory separator) any number of times, and `**` matches any
character including the directory separator any number of times.

Fixes #62