### PR TITLE
tree-wide: fix references to the terraform-providers organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 NOTES:
 
-* The provider has switched to the standalone TF SDK, there should be no noticeable impact on compatibility. ([#50](https://github.com/terraform-providers/terraform-provider-archive/issues/50))
+* The provider has switched to the standalone TF SDK, there should be no noticeable impact on compatibility. ([#50](https://github.com/hashicorp/terraform-provider-archive/issues/50))
 
 ## 1.2.2 (April 30, 2019)
 
@@ -23,30 +23,30 @@ IMPROVEMENTS:
 
 ENHANCEMENTS:
 
-* Add `excludes` to the `archive_file` data source to exclude files when using `source_dir` ([#18](https://github.com/terraform-providers/terraform-provider-archive/issues/18))
+* Add `excludes` to the `archive_file` data source to exclude files when using `source_dir` ([#18](https://github.com/hashicorp/terraform-provider-archive/issues/18))
 
 BUG FIXES:
 
-* Fix zip file path names to use forward slash on Windows ([#25](https://github.com/terraform-providers/terraform-provider-archive/issues/25))
-* Fix panic in `filepath.Walk` call ([#26](https://github.com/terraform-providers/terraform-provider-archive/issues/26))
+* Fix zip file path names to use forward slash on Windows ([#25](https://github.com/hashicorp/terraform-provider-archive/issues/25))
+* Fix panic in `filepath.Walk` call ([#26](https://github.com/hashicorp/terraform-provider-archive/issues/26))
 
 ## 1.0.3 (March 23, 2018)
 
 BUG FIXES:
 
-* Fix modified time affecting zip contents and causing spurious diffs ([#16](https://github.com/terraform-providers/terraform-provider-archive/issues/16))
+* Fix modified time affecting zip contents and causing spurious diffs ([#16](https://github.com/hashicorp/terraform-provider-archive/issues/16))
 
 ## 1.0.2 (March 16, 2018)
 
 BUG FIXES:
 
-* Fix issue with flags not being copied on a single file and regression introduced in 1.0.1 ([#13](https://github.com/terraform-providers/terraform-provider-archive/issues/13))
+* Fix issue with flags not being copied on a single file and regression introduced in 1.0.1 ([#13](https://github.com/hashicorp/terraform-provider-archive/issues/13))
 
 ## 1.0.1 (March 13, 2018)
 
 BUG FIXES:
 
-* Fix issue with flags not being copied in to archive ([#9](https://github.com/terraform-providers/terraform-provider-archive/issues/9))
+* Fix issue with flags not being copied in to archive ([#9](https://github.com/hashicorp/terraform-provider-archive/issues/9))
 
 ## 1.0.0 (September 15, 2017)
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-archive`
+Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-archive`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-archive
+$ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
+$ git clone git@github.com:hashicorp/terraform-provider-archive
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-archive
+$ cd $GOPATH/src/github.com/hashicorp/terraform-provider-archive
 $ make build
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-archive
+module github.com/hashicorp/terraform-provider-archive
 
 require (
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-archive/archive"
+	"github.com/hashicorp/terraform-provider-archive/archive"
 )
 
 func main() {

--- a/scripts/changelog-links.sh
+++ b/scripts/changelog-links.sh
@@ -24,7 +24,7 @@ else
   SED="sed -i.bak -r -e"
 fi
 
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-archive\/issues"
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-archive\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 

--- a/website/docs/d/archive_file.html.markdown
+++ b/website/docs/d/archive_file.html.markdown
@@ -42,7 +42,7 @@ data "archive_file" "dotfiles" {
 ~> **Note regarding symbolic links**: Due to a bug, the `archive_file` data
   source does not currently create proper zip archives when the source includes
   symbolic links (also known as "symlinks"). Please see [GitHub Issue
-  #6](https://github.com/terraform-providers/terraform-provider-archive/issues/6)
+  #6](https://github.com/hashicorp/terraform-provider-archive/issues/6)
   for more details and workaround options. This message will be removed when the
   bug is fixed.
 


### PR DESCRIPTION
`terraform-provider-archive` has been moved to the `hashicorp`
organization.