### PR TITLE
add output_sha256 attribute

### DIFF
--- a/archive/data_source_archive_file.go
+++ b/archive/data_source_archive_file.go
@@ -101,6 +101,12 @@ func dataSourceFile() *schema.Resource {
 				ForceNew:    true,
 				Description: "SHA1 checksum of output file",
 			},
+			"output_sha256": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Hex Encoded SHA256 checksum of output file",
+			},
 			"output_base64sha256": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -139,12 +145,13 @@ func dataSourceFileRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	sha1, base64sha256, md5, err := genFileShas(outputPath)
+	sha1, hexsha256, base64sha256, md5, err := genFileShas(outputPath)
 	if err != nil {
 
 		return fmt.Errorf("could not generate file checksum sha256: %s", err)
 	}
 	d.Set("output_sha", sha1)
+	d.Set("output_sha256", hexsha256)
 	d.Set("output_base64sha256", base64sha256)
 	d.Set("output_md5", md5)
 
@@ -208,10 +215,10 @@ func archive(d *schema.ResourceData) error {
 	return nil
 }
 
-func genFileShas(filename string) (string, string, string, error) {
+func genFileShas(filename string) (string, string, string, string, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return "", "", "", fmt.Errorf("could not compute file '%s' checksum: %s", filename, err)
+		return "", "", "", "", fmt.Errorf("could not compute file '%s' checksum: %s", filename, err)
 	}
 	h := sha1.New()
 	h.Write([]byte(data))
@@ -220,11 +227,12 @@ func genFileShas(filename string) (string, string, string, error) {
 	h256 := sha256.New()
 	h256.Write([]byte(data))
 	shaSum := h256.Sum(nil)
+	sha256hex := hex.EncodeToString(shaSum[:])
 	sha256base64 := base64.StdEncoding.EncodeToString(shaSum[:])
 
 	md5 := md5.New()
 	md5.Write([]byte(data))
 	md5Sum := hex.EncodeToString(md5.Sum(nil))
 
-	return sha1, sha256base64, md5Sum, nil
+	return sha1, sha256hex, sha256base64, md5Sum, nil
 }

--- a/archive/data_source_archive_file_test.go
+++ b/archive/data_source_archive_file_test.go
@@ -31,6 +31,9 @@ func TestAccArchiveFile_Basic(t *testing.T) {
 						regexp.MustCompile(`^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$`),
 					),
 					r.TestMatchResourceAttr(
+						"data.archive_file.foo", "output_sha256", regexp.MustCompile(`^[0-9a-f]{64}$`),
+					),
+					r.TestMatchResourceAttr(
 						"data.archive_file.foo", "output_md5", regexp.MustCompile(`^[0-9a-f]{32}$`),
 					),
 					r.TestMatchResourceAttr(

--- a/website/docs/d/archive_file.html.markdown
+++ b/website/docs/d/archive_file.html.markdown
@@ -84,6 +84,8 @@ The following attributes are exported:
 
 * `output_sha` - The SHA1 checksum of output archive file.
 
+* `output_sha256` - The hex-encoded SHA256 checksum of output archive file.
+
 * `output_base64sha256` - The base64-encoded SHA256 checksum of output archive file.
 
 * `output_md5` - The MD5 checksum of output archive file.


### PR DESCRIPTION
Hello!

I'm using this provider to create some archives for AWS SSM Distributor. AWS requires each package to have [a manifest with hex SHA256 sums](https://docs.aws.amazon.com/systems-manager/latest/userguide/distributor-working-with-packages-create.html#packages-manifest). As far as I can tell, there's no simple way to convert the base64 sum to a hex sum using Terraform functions, which I think makes it a good candidate for being done on the provider level.