### PR TITLE
added 'mode' argument

### DIFF
--- a/website/docs/d/archive_file.html.markdown
+++ b/website/docs/d/archive_file.html.markdown
@@ -66,6 +66,8 @@ NOTE: One of `source`, `source_content_filename` (with `source_content`), `sourc
 
 * `source_dir` - (Optional) Package entire contents of this directory into the archive.
 
+* `mode` - (Optional) Recursively set `source_file` or `source_dir` permissions to this before packaging.
+
 * `source` - (Optional) Specifies attributes of a single source file to include into the archive.
 
 * `excludes` - (Optional) Specify files to ignore when reading the `source_dir`.


### PR DESCRIPTION
Proposed solution for #17.

Adds the `mode` argument to the `archive_file` data source:
```hcl
data "archive_file" "test" {
  source_dir  = "src"
  output_path = "src.zip"
  type        = "zip"
  mode        = 755  // or 0755 (zero-trailed), doesn't matter
}
```

Works exclusively with `source_dir` or `source_file`.
It performs the equivalent of a `chmod -R ${mode} ${source_dir|source_file}` before deflating.

---

Tested with Terraform `v0.13.5`:
```
$ mkdir -p src/code
$ echo "is Hashicorp hiring SREs?" > src/code/test-one.txt
$ echo "if so, let me know ;P" > src/code/test-two.txt
$ chmod -R 700 src 
$ \ls -l src/code 
total 16
-rwx------  1 caretaker  staff  26 Jan 23 20:57 test-one.txt
-rwx------  1 caretaker  staff  22 Jan 23 20:58 test-two.txt


$ terraform apply
data.archive_file.test: Refreshing state... [id=4bab5837844bf9b668fc2e80172e86622db79742]

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.


$ rm -rf src
$ unzip src.zip 
Archive:  src.zip
  inflating: code/test-one.txt       
  inflating: code/test-two.txt       
$ \ls -l code 
total 16
-rwxr-xr-x  1 caretaker  staff  26 Jan  1  2049 test-one.txt
-rwxr-xr-x  1 caretaker  staff  22 Jan  1  2049 test-two.txt
$
```
Works as well with `source_file`.