### PR TITLE
Add sensitive_source block

### DIFF
--- a/internal/provider/data_source_archive_file.go
+++ b/internal/provider/data_source_archive_file.go
@@ -53,6 +53,34 @@ func dataSourceFile() *schema.Resource {
 					return hashcode.String(buf.String())
 				},
 			},
+			"sensitive_source": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"content": {
+							Type:      schema.TypeString,
+							Required:  true,
+							ForceNew:  true,
+							Sensitive: true,
+						},
+						"filename": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+				ConflictsWith: []string{"source_file", "source_dir", "source_content", "source_content_filename"},
+				Set: func(v interface{}) int {
+					var buf bytes.Buffer
+					m := v.(map[string]interface{})
+					buf.WriteString(fmt.Sprintf("%s-", m["filename"].(string)))
+					buf.WriteString(fmt.Sprintf("%s-", m["content"].(string)))
+					return hashcode.String(buf.String())
+				},
+			},
 			"source_content": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -193,19 +221,34 @@ func archive(d *schema.ResourceData) error {
 			return fmt.Errorf("error archiving content: %s", err)
 		}
 	} else if v, ok := d.GetOk("source"); ok {
-		vL := v.(*schema.Set).List()
-		content := make(map[string][]byte)
-		for _, v := range vL {
-			src := v.(map[string]interface{})
-			content[src["filename"].(string)] = []byte(src["content"].(string))
+		content := genFileContentMap(v)
+		if v, ok := d.GetOk("sensitive_source"); ok {
+			for fileName, fileContent := range genFileContentMap(v) {
+				content[fileName] = fileContent
+			}
 		}
 		if err := archiver.ArchiveMultiple(content); err != nil {
 			return fmt.Errorf("error archiving content: %s", err)
 		}
+	} else if v, ok := d.GetOk("sensitive_source"); ok {
+		content := genFileContentMap(v)
+		if err := archiver.ArchiveMultiple(content); err != nil {
+			return fmt.Errorf("error archiving content: %s", err)
+		}
 	} else {
-		return fmt.Errorf("one of 'source_dir', 'source_file', 'source_content_filename' must be specified")
+		return fmt.Errorf("one of 'source_dir', 'source_file', 'source_content_filename', 'source', 'sensitive_source' must be specified")
 	}
 	return nil
+}
+
+func genFileContentMap(v interface{}) map[string][]byte {
+	vL := v.(*schema.Set).List()
+	content := make(map[string][]byte)
+	for _, v := range vL {
+		src := v.(map[string]interface{})
+		content[src["filename"].(string)] = []byte(src["content"].(string))
+	}
+	return content
 }
 
 func genFileShas(filename string) (string, string, string, error) {

--- a/internal/provider/data_source_archive_file_test.go
+++ b/internal/provider/data_source_archive_file_test.go
@@ -73,6 +73,14 @@ func TestAccArchiveFile_Basic(t *testing.T) {
 					r.TestCheckResourceAttrPtr("data.archive_file.foo", "output_size", &fileSize),
 				),
 			},
+
+			{
+				Config: testAccArchiveFileSensitiveConfig(f),
+				Check: r.ComposeTestCheckFunc(
+					testAccArchiveFileExists(f, &fileSize),
+					r.TestCheckResourceAttrPtr("data.archive_file.foo", "output_size", &fileSize),
+				),
+			},
 		},
 	})
 }
@@ -136,6 +144,19 @@ func testAccArchiveFileMultiConfig(outputPath string) string {
 data "archive_file" "foo" {
 	type = "zip"
 	source {
+		filename = "content.txt"
+		content = "This is some content"
+	}
+	output_path = "%s"
+}
+`, filepath.ToSlash(outputPath))
+}
+
+func testAccArchiveFileSensitiveConfig(outputPath string) string {
+	return fmt.Sprintf(`
+data "archive_file" "foo" {
+	type = "zip"
+	sensitive_source {
 		filename = "content.txt"
 		content = "This is some content"
 	}

--- a/website/docs/d/archive_file.html.markdown
+++ b/website/docs/d/archive_file.html.markdown
@@ -37,6 +37,11 @@ data "archive_file" "dotfiles" {
     content  = "${data.template_file.ssh_config.rendered}"
     filename = ".ssh/config"
   }
+  
+  sensitive_source {
+    content = "This is sensitive content"
+    filename = ".ssh/id_rsa"
+  }
 }
 ```
 
@@ -68,11 +73,21 @@ NOTE: One of `source`, `source_content_filename` (with `source_content`), `sourc
 
 * `source` - (Optional) Specifies attributes of a single source file to include into the archive.
 
+* `sensitive_source` - (Optional) Specifies attributes of a single sensitive source file to include into the archive. 
+  Content will not be displayed in plans.
+
 * `excludes` - (Optional) Specify files to ignore when reading the `source_dir`.
 
 The `source` block supports the following:
 
 * `content` - (Required) Add this content to the archive with `filename` as the filename.
+
+* `filename` - (Required) Set this as the filename when declaring a `source`.
+
+The `sensitive_source` block supports the following:
+
+* `content` - (Required) Add this content to the archive with `filename` as the filename. 
+  Content will not be displayed in plans.
 
 * `filename` - (Required) Set this as the filename when declaring a `source`.
 


### PR DESCRIPTION
Adds a new sensitive source block which won't be rendered in terraform plans.

For example, here's a terraform configuration that will use this provider
<details>
<summary>main.tf</summary>

```
data "archive_file" "archive" {
  output_path = "certs.zip"
  type = "zip"

  sensitive_source {
    content = tls_private_key.pk.private_key_pem
    filename = "pk.pem"
  }

  source {
    content = tls_self_signed_cert.crt.cert_pem
    filename = "cert.pem"
  }
}

resource "tls_private_key" "pk" {
  algorithm = "RSA"
  rsa_bits = 2048
}

resource "tls_self_signed_cert" "crt" {
  allowed_uses = []
  key_algorithm = "RSA"
  private_key_pem = tls_private_key.pk.private_key_pem
  validity_period_hours = 24
  dns_names = ["*.landonwoerdeman.com"]
  subject {
    country = "US"
    province = "Iowa"
    locality = "Ames"
    organization = "Landon Woerdeman"
    common_name = "*.landonwoerdeman.com"
  }
}

# needed to trigger plan output
resource "null_resource" "do_nothing" {
  triggers = {
    always = timestamp()
  }
  provisioner "local-exec" {
    command = "echo done"
  }
}
```
</details>

When adjusting a value on the certificate, the plan would look like the following. Specifically, you can see that the private key contents aren't outputted to the console during the plan.
<details>
<summary>tfplan</summary>

```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

null_resource.do_nothing: Refreshing state... [id=4622476077227136761]
tls_private_key.pk: Refreshing state... [id=9c07ba198391a62ce2524ac27ea1115c99e07566]
tls_self_signed_cert.crt: Refreshing state... [id=17411721654946504328367726288512378649]
data.archive_file.archive: Refreshing state... [id=b227e966aae628ffeb8e23294d0cab91147dc169]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.archive will be read during apply
  # (config refers to values not yet known)
 <= data "archive_file" "archive"  {
      ~ id                  = "b227e966aae628ffeb8e23294d0cab91147dc169" -> (known after apply)
      ~ output_base64sha256 = "02fYwo5Ua1MMRL0ij8JEdruhJB7U38DPExeLEGOUjoI=" -> (known after apply)
      ~ output_md5          = "90f81ac8087d7fda4e182fe4950af234" -> (known after apply)
        output_path         = "certs.zip"
      ~ output_sha          = "b227e966aae628ffeb8e23294d0cab91147dc169" -> (known after apply)
      ~ output_size         = 2468 -> (known after apply)
        type                = "zip"

        sensitive_source {
            content  = (sensitive value)
            filename = "pk.pem"
        }

      - source {
          - content  = <<~EOT
                -----BEGIN CERTIFICATE-----
                MIIDiDCCAnCgAwIBAgIQDRlgKBlNd1owsExrFnpnGTANBgkqhkiG9w0BAQsFADBm
                MQswCQYDVQQGEwJVUzENMAsGA1UECBMESW93YTENMAsGA1UEBxMEQW1lczEZMBcG
                A1UEChMQTGFuZG9uIFdvZXJkZW1hbjEeMBwGA1UEAwwVKi5sYW5kb253b2VyZGVt
                YW4uY29tMB4XDTIxMDEyODIzMDM0NFoXDTIxMDEyOTIzMDM0NFowZjELMAkGA1UE
                BhMCVVMxDTALBgNVBAgTBElvd2ExDTALBgNVBAcTBEFtZXMxGTAXBgNVBAoTEExh
                bmRvbiBXb2VyZGVtYW4xHjAcBgNVBAMMFSoubGFuZG9ud29lcmRlbWFuLmNvbTCC
                ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMxG6PV40m3zK1xBGQH75BZq
                6MrUYav3m7/3Oi/d0UIoJ/QfzwqwFRIGh9aH8bZg07FHClSI3U5nqPYZzpPZ4FnS
                jgrGd94llld1ReGGCGoWRiRYp3z2B7FG9+XYKlwb/qL7WdXoczCAj1jDAOSYQ/sg
                RCsb4jSe6ppk3OERb3qk4sCVc4B4v0H5teq3BwiEqAaex3328jAm0MO1SuGaY20e
                B53Y84DHr0bwxAV3h5DF/h4miAl4Zk1/TzMLK0Vb1ygILXxevpK4qKLsyil1NQ+/
                yeBXTrFMRqDmeGIgs4AytI61hph+K4SZiHuifinJQzr5eHzXkAkXRrwZyYixQwcC
                AwEAAaMyMDAwDAYDVR0TAQH/BAIwADAgBgNVHREEGTAXghUqLmxhbmRvbndvZXJk
                ZW1hbi5jb20wDQYJKoZIhvcNAQELBQADggEBAG+8kqxUMwvYgoE4Nda+gxcNQU7U
                +d0T+P9yX9c5DC2RxzByfvgHK0zFbBH4snCOUHaorBTUXUIFh0wc0a2RygLauYS5
                CN8MLxsyR446OEYTDJCi5qbnM79TapU8kruoDyrCeLhYkU2CQofGJic2IRzROpTq
                +tawzPbVjeQw47H/vj/XDNxy3MWgYTCU1/ltcvGqQMi3zMuI+BPvfKk7PPMthnt6
                iRl2KuV6u7V7bEp+Ee4l9uMs52FRwDI5bhy6Bqohjy8rxFi3WjOJv5DJX17Lch8/
                3BeVhzfq0m9HejGE5pJL1bdNBZJ+ZTr8WGjTSk4LT9sEekpAqWC77kR8JrQ=
                -----END CERTIFICATE-----
            EOT -> null
          - filename = "cert.pem" -> null
        }
      + source {
          + content  = (known after apply)
          + filename = "cert.pem"
        }
    }

  # null_resource.do_nothing must be replaced
-/+ resource "null_resource" "do_nothing" {
      ~ id       = "4622476077227136761" -> (known after apply)
      ~ triggers = {
          - "always" = "2021-01-28T23:07:56Z"
        } -> (known after apply) # forces replacement
    }

  # tls_self_signed_cert.crt must be replaced
-/+ resource "tls_self_signed_cert" "crt" {
        allowed_uses          = []
      ~ cert_pem              = <<~EOT
            -----BEGIN CERTIFICATE-----
            MIIDiDCCAnCgAwIBAgIQDRlgKBlNd1owsExrFnpnGTANBgkqhkiG9w0BAQsFADBm
            MQswCQYDVQQGEwJVUzENMAsGA1UECBMESW93YTENMAsGA1UEBxMEQW1lczEZMBcG
            A1UEChMQTGFuZG9uIFdvZXJkZW1hbjEeMBwGA1UEAwwVKi5sYW5kb253b2VyZGVt
            YW4uY29tMB4XDTIxMDEyODIzMDM0NFoXDTIxMDEyOTIzMDM0NFowZjELMAkGA1UE
            BhMCVVMxDTALBgNVBAgTBElvd2ExDTALBgNVBAcTBEFtZXMxGTAXBgNVBAoTEExh
            bmRvbiBXb2VyZGVtYW4xHjAcBgNVBAMMFSoubGFuZG9ud29lcmRlbWFuLmNvbTCC
            ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMxG6PV40m3zK1xBGQH75BZq
            6MrUYav3m7/3Oi/d0UIoJ/QfzwqwFRIGh9aH8bZg07FHClSI3U5nqPYZzpPZ4FnS
            jgrGd94llld1ReGGCGoWRiRYp3z2B7FG9+XYKlwb/qL7WdXoczCAj1jDAOSYQ/sg
            RCsb4jSe6ppk3OERb3qk4sCVc4B4v0H5teq3BwiEqAaex3328jAm0MO1SuGaY20e
            B53Y84DHr0bwxAV3h5DF/h4miAl4Zk1/TzMLK0Vb1ygILXxevpK4qKLsyil1NQ+/
            yeBXTrFMRqDmeGIgs4AytI61hph+K4SZiHuifinJQzr5eHzXkAkXRrwZyYixQwcC
            AwEAAaMyMDAwDAYDVR0TAQH/BAIwADAgBgNVHREEGTAXghUqLmxhbmRvbndvZXJk
            ZW1hbi5jb20wDQYJKoZIhvcNAQELBQADggEBAG+8kqxUMwvYgoE4Nda+gxcNQU7U
            +d0T+P9yX9c5DC2RxzByfvgHK0zFbBH4snCOUHaorBTUXUIFh0wc0a2RygLauYS5
            CN8MLxsyR446OEYTDJCi5qbnM79TapU8kruoDyrCeLhYkU2CQofGJic2IRzROpTq
            +tawzPbVjeQw47H/vj/XDNxy3MWgYTCU1/ltcvGqQMi3zMuI+BPvfKk7PPMthnt6
            iRl2KuV6u7V7bEp+Ee4l9uMs52FRwDI5bhy6Bqohjy8rxFi3WjOJv5DJX17Lch8/
            3BeVhzfq0m9HejGE5pJL1bdNBZJ+ZTr8WGjTSk4LT9sEekpAqWC77kR8JrQ=
            -----END CERTIFICATE-----
        EOT -> (known after apply)
        dns_names             = [
            "*.landonwoerdeman.com",
        ]
        early_renewal_hours   = 0
      ~ id                    = "17411721654946504328367726288512378649" -> (known after apply)
        key_algorithm         = "RSA"
        private_key_pem       = (sensitive value)
      ~ ready_for_renewal     = false -> true
      ~ validity_end_time     = "2021-01-29T17:03:44.544971-06:00" -> (known after apply)
      ~ validity_period_hours = 24 -> 12 # forces replacement
      ~ validity_start_time   = "2021-01-28T17:03:44.544971-06:00" -> (known after apply)

      ~ subject {
            common_name    = "*.landonwoerdeman.com"
            country        = "US"
            locality       = "Ames"
            organization   = "Landon Woerdeman"
            province       = "Iowa"
          - street_address = [] -> null
        }
    }

Plan: 2 to add, 0 to change, 2 to destroy.
```
</details>