### PR TITLE
fix: prefer to set mod time to oldest allowed by zip

### DIFF
--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -59,8 +59,9 @@ func (a *ZipArchiver) ArchiveFile(infilename string) error {
 	}
 	fh.Name = filepath.ToSlash(fi.Name())
 	fh.Method = zip.Deflate
+	oldestZipSupportedModTime, _ := time.Parse(time.RFC3339, "1980-01-01T00:00:00+00:00")
 	// fh.Modified alone isn't enough when using a zero value
-	fh.SetModTime(time.Time{})
+	fh.SetModTime(oldestZipSupportedModTime)
 
 	f, err := a.writer.CreateHeader(fh)
 	if err != nil {
@@ -134,8 +135,9 @@ func (a *ZipArchiver) ArchiveDir(indirname string, excludes []string) error {
 		}
 		fh.Name = filepath.ToSlash(relname)
 		fh.Method = zip.Deflate
+		oldestZipSupportedModTime, _ := time.Parse(time.RFC3339, "1980-01-01T00:00:00+00:00")
 		// fh.Modified alone isn't enough when using a zero value
-		fh.SetModTime(time.Time{})
+		fh.SetModTime(oldestZipSupportedModTime)
 
 		f, err := a.writer.CreateHeader(fh)
 		if err != nil {


### PR DESCRIPTION
# What does it fix?

zip files generated by this plugin are great because if we produce a zip file of the same files in two distinct points in time it will produce a zip archive with exactly the same resulting hash :heart:.

But... in go `time.Time{}` is the zero time, the [documenation if very clear on it](https://golang.org/pkg/time/#Time):
> The zero value of type Time is January 1, year 1, 00:00:00.000000000 UTC

This leads to 2 major issues:
1. For many zip unarchivers (see note below), the oldest supported time is `1980-01-01 0:00 UTC` so we potentialy generate archives not supported by any zip unarchiver :zipper_mouth_face:.
2. On my Linux system at least, the files once unarchive on my local file system have dates in 2049, so in the future. And I can tell you that it leads some of my AWS lambda to crash when I distribute them through a zip created but this plugin :boom:.


# Notes

As spotted in https://www.mindprod.com/jgloss/zip.html:
> The format does not support dates prior to 1980-01-01 0:00 UTC . Avoid file dates 1980-01-01 or earlier (local or UTC time).

I'm not sur to generate the given date the best way that can be done in go, by the way I've tested the compiled module on a real situation and it fixes the issue I'm facing :wink:.