### PR TITLE
Add source_dirs field

### DIFF
--- a/internal/provider/archiver.go
+++ b/internal/provider/archiver.go
@@ -10,6 +10,7 @@ type Archiver interface {
 	ArchiveFile(infilename string) error
 	ArchiveDir(indirname string, excludes []string) error
 	ArchiveMultiple(content map[string][]byte) error
+	ArchiveMultipleDirs(dirs []interface{}, excludes []string) error
 	SetOutputFileMode(outputFileMode string)
 }
 

--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -94,6 +94,87 @@ func checkMatch(fileName string, excludes []string) (value bool) {
 	return false
 }
 
+func (a *ZipArchiver) ArchiveMultipleDirs(dirs []interface{}, excludes []string) error {
+	if err := a.open(); err != nil {
+		return err
+	}
+
+	defer a.close()
+
+	for _, indirname := range dirs {
+		indirname := indirname.(string)
+		_, err := assertValidDir(indirname)
+		if err != nil {
+			return err
+		}
+
+		// ensure exclusions are OS compatible paths
+		for i := range excludes {
+			excludes[i] = filepath.FromSlash(excludes[i])
+		}
+
+
+		filepath.Walk(indirname, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return fmt.Errorf("error encountered during file walk: %s", err)
+			}
+
+			relname, err := filepath.Rel(indirname, path)
+			if err != nil {
+				return fmt.Errorf("error relativizing file for archival: %s", err)
+			}
+
+			relname = fmt.Sprintf("%s/%s", filepath.Base(indirname), relname)
+
+			isMatch := checkMatch(relname, excludes)
+
+			if info.IsDir() {
+				if isMatch {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
+			if isMatch {
+				return nil
+			}
+
+			if err != nil {
+				return err
+			}
+
+			fh, err := zip.FileInfoHeader(info)
+			if err != nil {
+				return fmt.Errorf("error creating file header: %s", err)
+			}
+			fh.Name = filepath.ToSlash(relname)
+			fh.Method = zip.Deflate
+			// fh.Modified alone isn't enough when using a zero value
+			fh.SetModTime(time.Time{})
+
+			if a.outputFileMode != "" {
+				filemode, err := strconv.ParseUint(a.outputFileMode, 0, 32)
+				if err != nil {
+					return fmt.Errorf("error parsing output_file_mode value: %s", a.outputFileMode)
+				}
+				fh.SetMode(os.FileMode(filemode))
+			}
+
+			f, err := a.writer.CreateHeader(fh)
+			if err != nil {
+				return fmt.Errorf("error creating file inside archive: %s", err)
+			}
+			content, err := ioutil.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("error reading file for archival: %s", err)
+			}
+			_, err = f.Write(content)
+			return err
+		})
+	};
+	return nil
+}
+
 func (a *ZipArchiver) ArchiveDir(indirname string, excludes []string) error {
 	_, err := assertValidDir(indirname)
 	if err != nil {

--- a/website/docs/d/archive_file.html.markdown
+++ b/website/docs/d/archive_file.html.markdown
@@ -61,7 +61,7 @@ data "archive_file" "lambda_my_function" {
 
 The following arguments are supported:
 
-NOTE: One of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified.
+NOTE: One of `source`, `source_content_filename` (with `source_content`), `source_file`, `source_dir`, or `source_dirs` must be specified.
 
 * `type` - (Required) The type of archive to generate.
   NOTE: `zip` is supported.
@@ -77,6 +77,8 @@ NOTE: One of `source`, `source_content_filename` (with `source_content`), `sourc
 * `source_file` - (Optional) Package this file into the archive.
 
 * `source_dir` - (Optional) Package entire contents of this directory into the archive.
+
+* `source_dirs` - (Optional) Package multiple directory into the archive.
 
 * `source` - (Optional) Specifies attributes of a single source file to include into the archive.
 


### PR DESCRIPTION
Add source_dirs field which would allow archiving multiple dirs at once with the following structure

if `dir1` have `file1` and `dir2` have `file2` it would result in this 

```
dir1/file1
dir2/file2
```

terraform example:
```terraform
data "archive_file" "test-dirs" {
  type = "zip"
  output_path = "test.zip"

  source_dirs = [
    "./dir1",
    "./dir2"
  ]
}
```

The items need to be for this are adding test cases relate to this and ensure all errors from the filepath walk are return