### PR TITLE
Add archive_dir property to be used with source_dir that will prefix …

### DIFF
--- a/internal/provider/archiver.go
+++ b/internal/provider/archiver.go
@@ -8,7 +8,7 @@ import (
 type Archiver interface {
 	ArchiveContent(content []byte, infilename string) error
 	ArchiveFile(infilename string) error
-	ArchiveDir(indirname string, excludes []string) error
+	ArchiveDir(indirname string, excludes []string, archiveDirs string) error
 	ArchiveMultiple(content map[string][]byte) error
 	SetOutputFileMode(outputFileMode string)
 }

--- a/internal/provider/data_source_archive_file.go
+++ b/internal/provider/data_source_archive_file.go
@@ -77,6 +77,11 @@ func dataSourceFile() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"source_content", "source_content_filename", "source_file"},
 			},
+			"archive_dir": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"excludes": {
 				Type:          schema.TypeSet,
 				Optional:      true,
@@ -181,15 +186,18 @@ func archive(d *schema.ResourceData) error {
 		archiver.SetOutputFileMode(outputFileMode)
 	}
 
+	archiveDirs := d.Get("archive_dir").(string)
+
 	if dir, ok := d.GetOk("source_dir"); ok {
+
 		if excludes, ok := d.GetOk("excludes"); ok {
 			excludeList := expandStringList(excludes.(*schema.Set).List())
 
-			if err := archiver.ArchiveDir(dir.(string), excludeList); err != nil {
+			if err := archiver.ArchiveDir(dir.(string), excludeList, archiveDirs); err != nil {
 				return fmt.Errorf("error archiving directory: %s", err)
 			}
 		} else {
-			if err := archiver.ArchiveDir(dir.(string), []string{""}); err != nil {
+			if err := archiver.ArchiveDir(dir.(string), []string{""}, archiveDirs); err != nil {
 				return fmt.Errorf("error archiving directory: %s", err)
 			}
 		}

--- a/internal/provider/test-fixtures/test-dir/sub-dir1/file4.txt
+++ b/internal/provider/test-fixtures/test-dir/sub-dir1/file4.txt
@@ -1,0 +1,1 @@
+This is sub-dir1/file4.txt

--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -13,6 +13,7 @@ import (
 
 type ZipArchiver struct {
 	filepath       string
+	archiveDirs    string
 	outputFileMode string // Default value "" means unset
 	filewriter     *os.File
 	writer         *zip.Writer
@@ -94,7 +95,7 @@ func checkMatch(fileName string, excludes []string) (value bool) {
 	return false
 }
 
-func (a *ZipArchiver) ArchiveDir(indirname string, excludes []string) error {
+func (a *ZipArchiver) ArchiveDir(indirname string, excludes []string, archiveDirs string) error {
 	_, err := assertValidDir(indirname)
 	if err != nil {
 		return err
@@ -142,7 +143,7 @@ func (a *ZipArchiver) ArchiveDir(indirname string, excludes []string) error {
 		if err != nil {
 			return fmt.Errorf("error creating file header: %s", err)
 		}
-		fh.Name = filepath.ToSlash(relname)
+		fh.Name = filepath.Join(archiveDirs, filepath.ToSlash(relname))
 		fh.Method = zip.Deflate
 		// fh.Modified alone isn't enough when using a zero value
 		fh.SetModTime(time.Time{})

--- a/internal/provider/zip_archiver_test.go
+++ b/internal/provider/zip_archiver_test.go
@@ -99,34 +99,51 @@ func TestZipArchiver_FileModified(t *testing.T) {
 func TestZipArchiver_Dir(t *testing.T) {
 	zipfilepath := "archive-dir.zip"
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{""}); err != nil {
+	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{""}, ""); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	ensureContents(t, zipfilepath, map[string][]byte{
-		"file1.txt": []byte("This is file 1"),
-		"file2.txt": []byte("This is file 2"),
-		"file3.txt": []byte("This is file 3"),
+		"file1.txt":          []byte("This is file 1"),
+		"file2.txt":          []byte("This is file 2"),
+		"file3.txt":          []byte("This is file 3"),
+		"sub-dir1/file4.txt": []byte("This is sub-dir1/file4.txt"),
+	})
+}
+
+func TestZipArchiver_Dir_WithArchiveDirs(t *testing.T) {
+	zipfilepath := "archive-dir.zip"
+	archiver := NewZipArchiver(zipfilepath)
+	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{""}, "root/test-dir"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureContents(t, zipfilepath, map[string][]byte{
+		"root/test-dir/file1.txt":          []byte("This is file 1"),
+		"root/test-dir/file2.txt":          []byte("This is file 2"),
+		"root/test-dir/file3.txt":          []byte("This is file 3"),
+		"root/test-dir/sub-dir1/file4.txt": []byte("This is sub-dir1/file4.txt"),
 	})
 }
 
 func TestZipArchiver_Dir_Exclude(t *testing.T) {
 	zipfilepath := "archive-dir.zip"
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{"file2.txt"}); err != nil {
+	if err := archiver.ArchiveDir("./test-fixtures/test-dir", []string{"file2.txt"}, "root"); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
 	ensureContents(t, zipfilepath, map[string][]byte{
-		"file1.txt": []byte("This is file 1"),
-		"file3.txt": []byte("This is file 3"),
+		"root/file1.txt":          []byte("This is file 1"),
+		"root/file3.txt":          []byte("This is file 3"),
+		"root/sub-dir1/file4.txt": []byte("This is sub-dir1/file4.txt"),
 	})
 }
 
 func TestZipArchiver_Dir_Exclude_With_Directory(t *testing.T) {
 	zipfilepath := "archive-dir.zip"
 	archiver := NewZipArchiver(zipfilepath)
-	if err := archiver.ArchiveDir("./test-fixtures/", []string{"test-dir", "test-dir2/file2.txt"}); err != nil {
+	if err := archiver.ArchiveDir("./test-fixtures/", []string{"test-dir", "test-dir2/file2.txt"}, ""); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 

--- a/website/docs/d/archive_file.html.markdown
+++ b/website/docs/d/archive_file.html.markdown
@@ -78,6 +78,8 @@ NOTE: One of `source`, `source_content_filename` (with `source_content`), `sourc
 
 * `source_dir` - (Optional) Package entire contents of this directory into the archive.
 
+* `archive_dir` - (Optional) When used with source_dir, the top-level directories inside the archive that will contain all the contents
+
 * `source` - (Optional) Specifies attributes of a single source file to include into the archive.
 
 * `excludes` - (Optional) Specify files to ignore when reading the `source_dir`.


### PR DESCRIPTION
…all content

This can be used to address issue issue #96 and feature request #37. To keep the parent directory, it just must be specified in archive_dir property. archive_dir can have multiple parent levels, if needed. As this uses a new field, it does not regress any current behavior.
