### PR TITLE
ci: merging `golangci-lint` rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,24 @@
-linters:
-  # Default linters enabled
-  # See: https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
 
-  # Additional linters enabled
+linters:
+  disable-all: true
   enable:
     - durationcheck
+    - errcheck
     - exportloopref
-    - godot
+    - forcetypeassert
     - gofmt
+    - gosimple
+    - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
+    - staticcheck
     - tenv
     - unconvert
     - unparam
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
+    - unused
+    - vet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - errcheck
     - exportloopref
     - forcetypeassert
+    - godot
     - gofmt
     - gosimple
     - ineffassign


### PR DESCRIPTION
contributes to:
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/102

### Notes
- Skipping `paralleltest` for the providers
