### PR TITLE
Add glob file pattern matching support for the `excludes` attribute.

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240724-160724.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240724-160724.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'data-source/archive_file: Add glob pattern matching support to the `excludes` attribute.'
+time: 2024-07-24T16:07:24.058378-04:00
+custom:
+    Issue: "354"

--- a/.changes/unreleased/ENHANCEMENTS-20240724-160830.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240724-160830.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'resource/archive_file: Add glob pattern matching support to the `excludes` attribute.'
+time: 2024-07-24T16:08:30.211413-04:00
+custom:
+    Issue: "354"

--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -63,7 +63,7 @@ data "archive_file" "lambda_my_function" {
 ### Optional
 
 - `exclude_symlink_directories` (Boolean) Boolean flag indicating whether symbolically linked directories should be excluded during the creation of the archive. Defaults to `false`.
-- `excludes` (Set of String) Specify files/directories to ignore when reading the `source_dir`. Supports glob file matching patterns including doublestar/globstar (`**`) patterns
+- `excludes` (Set of String) Specify files/directories to ignore when reading the `source_dir`. Supports glob file matching patterns including doublestar/globstar (`**`) patterns.
 - `output_file_mode` (String) String that specifies the octal file mode for all archived files. For example: `"0666"`. Setting this will ensure that cross platform usage of this module will not vary the modes of archived files (and ultimately checksums) resulting in more deterministic behavior.
 - `source` (Block Set) Specifies attributes of a single source file to include into the archive. One and only one of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified. (see [below for nested schema](#nestedblock--source))
 - `source_content` (String) Add only this content to the archive with `source_content_filename` as the filename. One and only one of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified.

--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -63,7 +63,7 @@ data "archive_file" "lambda_my_function" {
 ### Optional
 
 - `exclude_symlink_directories` (Boolean) Boolean flag indicating whether symbolically linked directories should be excluded during the creation of the archive. Defaults to `false`.
-- `excludes` (Set of String) Specify files to ignore when reading the `source_dir`.
+- `excludes` (Set of String) Specify files/directories to ignore when reading the `source_dir`. Supports glob file matching patterns including doublestar/globstar (`**`) patterns
 - `output_file_mode` (String) String that specifies the octal file mode for all archived files. For example: `"0666"`. Setting this will ensure that cross platform usage of this module will not vary the modes of archived files (and ultimately checksums) resulting in more deterministic behavior.
 - `source` (Block Set) Specifies attributes of a single source file to include into the archive. One and only one of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified. (see [below for nested schema](#nestedblock--source))
 - `source_content` (String) Add only this content to the archive with `source_content_filename` as the filename. One and only one of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified.

--- a/docs/resources/file.md
+++ b/docs/resources/file.md
@@ -23,7 +23,7 @@ description: |-
 ### Optional
 
 - `exclude_symlink_directories` (Boolean) Boolean flag indicating whether symbolically linked directories should be excluded during the creation of the archive. Defaults to `false`.
-- `excludes` (Set of String) Specify files to ignore when reading the `source_dir`.
+- `excludes` (Set of String) Specify files/directories to ignore when reading the `source_dir`. Supports glob file matching patterns including doublestar/globstar (`**`) patterns
 - `output_file_mode` (String) String that specifies the octal file mode for all archived files. For example: `"0666"`. Setting this will ensure that cross platform usage of this module will not vary the modes of archived files (and ultimately checksums) resulting in more deterministic behavior.
 - `source` (Block Set) Specifies attributes of a single source file to include into the archive. One and only one of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified. (see [below for nested schema](#nestedblock--source))
 - `source_content` (String) Add only this content to the archive with `source_content_filename` as the filename. One and only one of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified.

--- a/docs/resources/file.md
+++ b/docs/resources/file.md
@@ -23,7 +23,7 @@ description: |-
 ### Optional
 
 - `exclude_symlink_directories` (Boolean) Boolean flag indicating whether symbolically linked directories should be excluded during the creation of the archive. Defaults to `false`.
-- `excludes` (Set of String) Specify files/directories to ignore when reading the `source_dir`. Supports glob file matching patterns including doublestar/globstar (`**`) patterns
+- `excludes` (Set of String) Specify files/directories to ignore when reading the `source_dir`. Supports glob file matching patterns including doublestar/globstar (`**`) patterns.
 - `output_file_mode` (String) String that specifies the octal file mode for all archived files. For example: `"0666"`. Setting this will ensure that cross platform usage of this module will not vary the modes of archived files (and ultimately checksums) resulting in more deterministic behavior.
 - `source` (Block Set) Specifies attributes of a single source file to include into the archive. One and only one of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified. (see [below for nested schema](#nestedblock--source))
 - `source_content` (String) Add only this content to the archive with `source_content_filename` as the filename. One and only one of `source`, `source_content_filename` (with `source_content`), `source_file`, or `source_dir` must be specified.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 toolchain go1.21.3
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/hashicorp/terraform-plugin-framework v1.10.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
+github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
+github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=

--- a/internal/provider/data_source_archive_file.go
+++ b/internal/provider/data_source_archive_file.go
@@ -135,7 +135,7 @@ func (d *archiveFileDataSource) Schema(ctx context.Context, req datasource.Schem
 			},
 			"excludes": schema.SetAttribute{
 				Description: "Specify files/directories to ignore when reading the `source_dir`. " +
-					"Supports glob file matching patterns including doublestar/globstar (`**`) patterns",
+					"Supports glob file matching patterns including doublestar/globstar (`**`) patterns.",
 				ElementType: types.StringType,
 				Optional:    true,
 				Validators: []validator.Set{

--- a/internal/provider/data_source_archive_file.go
+++ b/internal/provider/data_source_archive_file.go
@@ -134,7 +134,8 @@ func (d *archiveFileDataSource) Schema(ctx context.Context, req datasource.Schem
 				},
 			},
 			"excludes": schema.SetAttribute{
-				Description: "Specify files to ignore when reading the `source_dir`.",
+				Description: "Specify files/directories to ignore when reading the `source_dir`. " +
+					"Supports glob file matching patterns including doublestar/globstar (`**`) patterns",
 				ElementType: types.StringType,
 				Optional:    true,
 				Validators: []validator.Set{

--- a/internal/provider/data_source_archive_file_test.go
+++ b/internal/provider/data_source_archive_file_test.go
@@ -106,6 +106,13 @@ func TestAccArchiveFile_Basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccArchiveFileDirExcludesGlobConfig(f),
+				Check: r.ComposeTestCheckFunc(
+					testAccArchiveFileSize(f, &fileSize),
+					r.TestCheckResourceAttrPtr("data.archive_file.foo", "output_size", &fileSize),
+				),
+			},
+			{
 				Config: testAccArchiveFileMultiSourceConfig(f),
 				Check: r.ComposeTestCheckFunc(
 					testAccArchiveFileSize(f, &fileSize),
@@ -1384,6 +1391,17 @@ data "archive_file" "foo" {
   type        = "zip"
   source_dir  = "test-fixtures/test-dir/test-dir1"
   excludes    = ["test-fixtures/test-dir/test-dir1/file2.txt"]
+  output_path = "%s"
+}
+`, filepath.ToSlash(outputPath))
+}
+
+func testAccArchiveFileDirExcludesGlobConfig(outputPath string) string {
+	return fmt.Sprintf(`
+data "archive_file" "foo" {
+  type        = "zip"
+  source_dir  = "test-fixtures/test-dir/test-dir1"
+  excludes    = ["test-fixtures/test-dir/test-dir1/file2.txt", "**/file[2-3].txt"]
   output_path = "%s"
 }
 `, filepath.ToSlash(outputPath))

--- a/internal/provider/resource_archive_file.go
+++ b/internal/provider/resource_archive_file.go
@@ -155,7 +155,7 @@ func (d *archiveFileResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"excludes": schema.SetAttribute{
 				Description: "Specify files/directories to ignore when reading the `source_dir`. " +
-					"Supports glob file matching patterns including doublestar/globstar (`**`) patterns",
+					"Supports glob file matching patterns including doublestar/globstar (`**`) patterns.",
 				ElementType: types.StringType,
 				Optional:    true,
 				Validators: []validator.Set{

--- a/internal/provider/resource_archive_file.go
+++ b/internal/provider/resource_archive_file.go
@@ -154,7 +154,8 @@ func (d *archiveFileResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 			},
 			"excludes": schema.SetAttribute{
-				Description: "Specify files to ignore when reading the `source_dir`.",
+				Description: "Specify files/directories to ignore when reading the `source_dir`. " +
+					"Supports glob file matching patterns including doublestar/globstar (`**`) patterns",
 				ElementType: types.StringType,
 				Optional:    true,
 				Validators: []validator.Set{

--- a/internal/provider/resource_archive_file_test.go
+++ b/internal/provider/resource_archive_file_test.go
@@ -105,6 +105,13 @@ func TestAccArchiveFile_Resource_Basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccArchiveFileResourceDirExcludesGlobConfig(f),
+				Check: r.ComposeTestCheckFunc(
+					testAccArchiveFileSize(f, &fileSize),
+					r.TestCheckResourceAttrPtr("archive_file.foo", "output_size", &fileSize),
+				),
+			},
+			{
 				Config: testAccArchiveFileResourceMultiSourceConfig(f),
 				Check: r.ComposeTestCheckFunc(
 					testAccArchiveFileSize(f, &fileSize),
@@ -1480,6 +1487,17 @@ resource "archive_file" "foo" {
   type        = "zip"
   source_dir  = "test-fixtures/test-dir"
   excludes    = ["test-fixtures/test-dir/file2.txt"]
+  output_path = "%s"
+}
+`, filepath.ToSlash(outputPath))
+}
+
+func testAccArchiveFileResourceDirExcludesGlobConfig(outputPath string) string {
+	return fmt.Sprintf(`
+resource "archive_file" "foo" {
+  type        = "zip"
+  source_dir  = "test-fixtures/test-dir"
+  excludes    = ["test-fixtures/test-dir/file2.txt", "**/file[2-3].txt"]
   output_path = "%s"
 }
 `, filepath.ToSlash(outputPath))

--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -150,7 +150,7 @@ func (a *ZipArchiver) createWalkFunc(basePath, indirname string, opts ArchiveDir
 
 		isMatch, err := checkMatch(archivePath, opts.Excludes)
 		if err != nil {
-			return fmt.Errorf("error checking excludes matches: %s", err)
+			return fmt.Errorf("error checking excludes matches: %w", err)
 		}
 
 		if info.IsDir() {

--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -91,7 +91,7 @@ func checkMatch(fileName string, excludes []string) (value bool, err error) {
 			continue
 		}
 
-		match, err := doublestar.Match(exclude, fileName)
+		match, err := doublestar.PathMatch(exclude, fileName)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Resolves: #62 
Closes: #57 
Closes: #86 
Closes: #98 

Add glob file pattern matching to the `excludes` attributes for the `archive_file` data source and resource. Supports doublestar `**` pattern matching with the `bmatcuk/doublestar` library.