### PR TITLE
361: Don't return filepath.SkipDir from the WalkFunc when excluding symlinked directories…

### DIFF
--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -179,7 +179,10 @@ func (a *ZipArchiver) createWalkFunc(basePath, indirname string, opts ArchiveDir
 				if !opts.ExcludeSymlinkDirectories {
 					return filepath.Walk(realPath, a.createWalkFunc(archivePath, realPath, opts, isArchiveEmpty, dryRun))
 				} else {
-					return filepath.SkipDir
+					// Don't return filepath.SkipDir here, as the item at the path being processed is a symlink
+					// and according to https://pkg.go.dev/path/filepath#WalkFunc, returning filepath.SkipDir from WalkFunc
+					// will skip the parent directory containing the symlink, which is not the desired behavior.
+					return nil
 				}
 			}
 


### PR DESCRIPTION
…, as the item at the path being processed is a symlink and according to https://pkg.go.dev/path/filepath#WalkFunc, returning filepath.SkipDir from WalkFunc when the item being processed is not a directory will skip the parent directory - which is not the desired behavior.