### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - godot
     - gofmt
     - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
@@ -22,7 +23,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet
 
 run:
   # Prevent false positive timeouts in CI

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ version it implements, and Terraform:
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads)
-* [Go](https://go.dev/doc/install) (1.21)
+* [Go](https://go.dev/doc/install) (1.22)
 * [GNU Make](https://www.gnu.org/software/make/)
 * [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/terraform-provider-archive
 
-go 1.21
-
-toolchain go1.21.3
+go 1.22.7
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require (
 	github.com/hashicorp/copywrite v0.19.0


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.7