### PR TITLE
workflows: Add setup-terraform before doc generation step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
       with:
         version: latest
 
+    # We need the latest version of Terraform for our documentation generation tool to use
+    - name: Set up Terraform
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      with:
+        terraform_wrapper: false
+
     - name: Generate
       run: make generate
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         version: latest
 
-    # We need the latest version of Terraform for our documentation generation tool to use
+    # We need the latest version of Terraform for our tool formatting to use
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         version: latest
 
-    # We need the latest version of Terraform for our tool formatting to use
+    # We need the latest version of Terraform for our documentation generation to use
     - name: Set up Terraform
       uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       with:


### PR DESCRIPTION
Latest GHA images don't have terraform installed by default, ref: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md