### PR TITLE
[Chore] Upgrade Go version to 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ version it implements, and Terraform:
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads)
-* [Go](https://go.dev/doc/install) (1.23)
+* [Go](https://go.dev/doc/install) (1.24)
 * [GNU Make](https://www.gnu.org/software/make/)
 * [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-archive
 
-go 1.23.7
+go 1.24.8
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.23.7
+go 1.24.8
 
 require (
 	github.com/hashicorp/copywrite v0.22.0


### PR DESCRIPTION
## Description

Updates `go.mod` and `tools/go.mod` to next Go version.

Note: auto-merge has been turned on for this repo.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
N/A
