### PR TITLE
zip_archiver: stream source files via os.Open + io.Copy

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260426-180340.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260426-180340.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: 'data/archive_file: Stream source files via os.Open + io.Copy in zip archiver to reduce memory usage'
+time: 2026-04-26T18:03:40.786955+02:00
+custom:
+    Issue: "500"

--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -6,6 +6,7 @@ package archive
 import (
 	"archive/zip"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -48,11 +49,11 @@ func (a *ZipArchiver) ArchiveFile(infilename string) error {
 	if err != nil {
 		return err
 	}
-
-	content, err := os.ReadFile(infilename)
+	infile, err := os.Open(infilename)
 	if err != nil {
 		return err
 	}
+	defer infile.Close()
 
 	if err := a.open(); err != nil {
 		return err
@@ -81,7 +82,7 @@ func (a *ZipArchiver) ArchiveFile(infilename string) error {
 		return fmt.Errorf("error creating file inside archive: %s", err)
 	}
 
-	_, err = f.Write(content)
+	_, err = io.Copy(f, infile)
 	return err
 }
 
@@ -214,11 +215,13 @@ func (a *ZipArchiver) createWalkFunc(basePath, indirname string, opts ArchiveDir
 		if err != nil {
 			return fmt.Errorf("error creating file inside archive: %s", err)
 		}
-		content, err := os.ReadFile(path)
+		infile, err := os.Open(path)
 		if err != nil {
 			return fmt.Errorf("error reading file for archival: %s", err)
 		}
-		_, err = f.Write(content)
+		defer infile.Close()
+
+		_, err = io.Copy(f, infile)
 		return err
 	}
 }


### PR DESCRIPTION
## Related Issue

Related to #500 

## Description

Replaces `os.ReadFile` + `f.Write(content)` with `os.Open` + `io.Copy` in two call sites in `zip_archiver.go`:
 
- `ArchiveFile` (line 52): reads single source file for `source_file` configs
- `createWalkFunc` closure (line 217): reads each file during `source_dir` directory walks
This matches the streaming pattern already used in `tar_archiver.go`'s `addFile` function.
 
**What changes:**
 
The zip archiver no longer allocates a `[]byte` the size of each source file. Instead it streams from an `os.File` reader through `io.Copy` into the `zip.Writer`. The `zip.Writer.CreateHeader` returns an `io.Writer` backed by a `flate.Writer` + `crc32.Writer` — both are streaming-compatible, so no buffering is needed on the write side.
 
**Error-handling ordering preserved:** In `ArchiveFile`, the original code validated the input file (via `os.ReadFile`) before opening the output zip (via `a.open()`). The patch preserves this by placing `os.Open` at the same position as the original `os.ReadFile` — before `a.open()`. If the input is unreadable, the method returns an error without creating an empty output zip.
 
**What doesn't change:**
 
- `genFileChecksums` in `data_source_archive_file.go` still uses `os.ReadFile` on the finished output archive. That is a separate concern with different trade-offs (hashing the complete archive vs. streaming individual source files) and is intentionally out of scope.
- `ArchiveContent` and `ArchiveMultiple` accept `[]byte` arguments from callers — they don't read files, so streaming doesn't apply.
- All existing unit and acceptance tests pass. No new tests added because the existing test suite covers all zip code paths (content, single file, directory, symlinks, excludes, file mode) and verifies output checksums.
**Measurements:**
 
| Metric | Before | After | Change |
|---|---|---|---|
| Terraform peak RSS (10×50 MB, parallelism=10) | 1034 MB | 533 MB | -48% |
| Go benchmark heap (10×50 MB concurrent) | 508 MB | 8 MB | -98% |
 
Wall time within ±3% across all scenarios.
 
Reproducer with full methodology: https://github.com/olegmmv/terraform-archive-memory-research
 
The Terraform-level reduction is -48% rather than -98% because `genFileChecksums` contributes a second `os.ReadFile` on the output path — see scope note above.
 
Archive output content is identical — checksums computed by `genFileChecksums` match the buffered version (verified by existing acceptance tests).


## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls. This change modifies how source file bytes are read (streaming vs. buffered) without affecting access controls, encryption, or logging.


