### PR TITLE
Fix #467: Normalize file permissions for deterministic archive checksums across platforms

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260727-192908.yaml
+++ b/.changes/unreleased/BUG FIXES-20260727-192908.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'data-source/archive_file: Normalize file permissions for source block content to ensure deterministic checksums across platforms'
+time: 2026-07-27T19:29:08.343798+02:00
+custom:
+    Issue: "467"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ website/vendor
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/
+*.tar.gz

--- a/internal/provider/tar_archiver.go
+++ b/internal/provider/tar_archiver.go
@@ -301,6 +301,8 @@ func (a *TarArchiver) addContent(content []byte, header *tar.Header) error {
 			return fmt.Errorf("error parsing output_file_mode value: %s", a.outputFileMode)
 		}
 		header.Mode = filemode
+	} else if header.Mode == 0 {
+		header.Mode = 0644
 	}
 
 	if err := a.tarWriter.WriteHeader(header); err != nil {

--- a/internal/provider/tar_archiver_test.go
+++ b/internal/provider/tar_archiver_test.go
@@ -44,6 +44,17 @@ func TestTarArchiver_File(t *testing.T) {
 	})
 }
 
+func TestTarArchiver_Content_DefaultMode(t *testing.T) {
+	tarFilePath := filepath.Join(t.TempDir(), "archive-content-default-mode.tar.gz")
+
+	archiver := NewTarGzArchiver(tarFilePath)
+	if err := archiver.ArchiveContent([]byte("content"), "file.txt"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureTarFileMode(t, tarFilePath, "0644")
+}
+
 //nolint:usetesting
 func TestTarArchiver_FileMode(t *testing.T) {
 	file, err := os.CreateTemp("", "archive-file-mode-test.tar.gz")

--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -6,6 +6,7 @@ package archive
 import (
 	"archive/zip"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -34,7 +35,7 @@ func (a *ZipArchiver) ArchiveContent(content []byte, infilename string) error {
 	}
 	defer a.close()
 
-	f, err := a.writer.Create(filepath.ToSlash(infilename))
+	f, err := a.createEntry(filepath.ToSlash(infilename))
 	if err != nil {
 		return err
 	}
@@ -223,6 +224,27 @@ func (a *ZipArchiver) createWalkFunc(basePath, indirname string, opts ArchiveDir
 	}
 }
 
+func (a *ZipArchiver) createEntry(name string) (io.Writer, error) {
+	if a.outputFileMode == "" {
+		return a.writer.Create(name)
+	}
+
+	filemode, err := strconv.ParseUint(a.outputFileMode, 0, 32)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing output_file_mode value: %s", a.outputFileMode)
+	}
+
+	fh := &zip.FileHeader{
+		Name:   name,
+		Method: zip.Deflate,
+	}
+	fh.SetMode(os.FileMode(filemode))
+	//nolint:staticcheck // This is required as fh.SetModTime has been deprecated since Go 1.10 and using fh.Modified alone isn't enough when using a zero value
+	fh.SetModTime(time.Time{})
+
+	return a.writer.CreateHeader(fh)
+}
+
 func (a *ZipArchiver) ArchiveMultiple(content map[string][]byte) error {
 	if err := a.open(); err != nil {
 		return err
@@ -239,7 +261,7 @@ func (a *ZipArchiver) ArchiveMultiple(content map[string][]byte) error {
 	sort.Strings(keys)
 
 	for _, filename := range keys {
-		f, err := a.writer.Create(filepath.ToSlash(filename))
+		f, err := a.createEntry(filepath.ToSlash(filename))
 		if err != nil {
 			return err
 		}

--- a/internal/provider/zip_archiver_test.go
+++ b/internal/provider/zip_archiver_test.go
@@ -14,6 +14,18 @@ import (
 	"time"
 )
 
+func TestZipArchiver_Content_WithOutputFileMode(t *testing.T) {
+	zipFilePath := filepath.Join(t.TempDir(), "archive-content-filemode.zip")
+
+	archiver := NewZipArchiver(zipFilePath)
+	archiver.SetOutputFileMode("0700")
+	if err := archiver.ArchiveContent([]byte("content"), "file.txt"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureFileMode(t, zipFilePath, "0700")
+}
+
 func TestZipArchiver_Content(t *testing.T) {
 	zipFilePath := filepath.Join(t.TempDir(), "archive-content.zip")
 


### PR DESCRIPTION
## Related Issue

Fixes #467

## Description

This PR addresses non-deterministic archive checksums across different operating systems. The root cause is that file permissions differ between OSs (e.g., 664 vs 644) and between tar/zip archivers handling of `source` block content.

### Changes

1. **tar_archiver.go (`addContent`)**: Default file mode to `0644` for source block content when `output_file_mode` is unset (was `0`, which is invalid for most consumers).

2. **zip_archiver.go**: Added `createEntry` helper that respects `output_file_mode` for entries created via `ArchiveContent` and `ArchiveMultiple`. Previously these methods used `writer.Create()` which ignored `output_file_mode`.

### Impact

- `source { content = ... }` and `source_content` blocks now produce deterministic archives regardless of the host OS
- `output_file_mode` now applies correctly to zip source block entries (was previously only applied to `source_file`/`source_dir`)
- Backward compatible: when `output_file_mode` is not set, zip behavior is unchanged (defaults to 0644); tar source blocks change from mode 0 to 0644 (fixing a bug)

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls. This change normalizes file permissions in archives for deterministic output.