### PR TITLE
Fix #5: Resolve symlinks in source_dir path before directory walk

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260727-193401.yaml
+++ b/.changes/unreleased/BUG FIXES-20260727-193401.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'data-source/archive_file: Fix panic when source_dir contains symlinks or relative path traversals'
+time: 2026-07-27T19:34:01.048933+02:00
+custom:
+    Issue: "5"

--- a/internal/provider/tar_archiver.go
+++ b/internal/provider/tar_archiver.go
@@ -86,6 +86,11 @@ func (a *TarArchiver) ArchiveDir(indirname string, opts ArchiveDirOpts) error {
 		return err
 	}
 
+	indirname, err = filepath.EvalSymlinks(indirname)
+	if err != nil {
+		return fmt.Errorf("error resolving directory path: %s", err)
+	}
+
 	// ensure exclusions are OS compatible paths
 	for i := range opts.Excludes {
 		opts.Excludes[i] = filepath.FromSlash(opts.Excludes[i])

--- a/internal/provider/tar_archiver_test.go
+++ b/internal/provider/tar_archiver_test.go
@@ -154,6 +154,32 @@ func TestTarArchiver_Dir_Exclude_With_Directory(t *testing.T) {
 	})
 }
 
+func TestTarArchiver_Dir_WithSymlinkedParent(t *testing.T) {
+	td := t.TempDir()
+	realDir := filepath.Join(td, "real", "src")
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "file.txt"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	linkDir := filepath.Join(td, "link")
+	if err := os.Symlink(filepath.Join(td, "real"), linkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	tarFilePath := filepath.Join(td, "out.tar.gz")
+	archiver := NewTarGzArchiver(tarFilePath)
+	if err := archiver.ArchiveDir(filepath.Join(linkDir, "../link/src"), ArchiveDirOpts{}); err != nil {
+		t.Fatalf("unexpected error with symlinked parent path: %s", err)
+	}
+
+	ensureTarContents(t, tarFilePath, map[string][]byte{
+		"file.txt": []byte("content"),
+	})
+}
+
 func TestTarArchiver_Multiple(t *testing.T) {
 	tarFilePath := filepath.Join(t.TempDir(), "archive-content.tar.gz")
 

--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -109,6 +109,11 @@ func (a *ZipArchiver) ArchiveDir(indirname string, opts ArchiveDirOpts) error {
 		return err
 	}
 
+	indirname, err = filepath.EvalSymlinks(indirname)
+	if err != nil {
+		return fmt.Errorf("error resolving directory path: %s", err)
+	}
+
 	// ensure exclusions are OS compatible paths
 	for i := range opts.Excludes {
 		opts.Excludes[i] = filepath.FromSlash(opts.Excludes[i])

--- a/internal/provider/zip_archiver_test.go
+++ b/internal/provider/zip_archiver_test.go
@@ -150,6 +150,32 @@ func TestZipArchiver_Dir_Exclude_With_Directory(t *testing.T) {
 	})
 }
 
+func TestZipArchiver_Dir_WithSymlinkedParent(t *testing.T) {
+	td := t.TempDir()
+	realDir := filepath.Join(td, "real", "src")
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(realDir, "file.txt"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	linkDir := filepath.Join(td, "link")
+	if err := os.Symlink(filepath.Join(td, "real"), linkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	zipFilePath := filepath.Join(td, "out.zip")
+	archiver := NewZipArchiver(zipFilePath)
+	if err := archiver.ArchiveDir(filepath.Join(linkDir, "../link/src"), ArchiveDirOpts{}); err != nil {
+		t.Fatalf("unexpected error with symlinked parent path: %s", err)
+	}
+
+	ensureContents(t, zipFilePath, map[string][]byte{
+		"file.txt": []byte("content"),
+	})
+}
+
 func TestZipArchiver_Multiple(t *testing.T) {
 	zipFilePath := filepath.Join(t.TempDir(), "archive-content.zip")
 


### PR DESCRIPTION
## Related Issue

Fixes #5

## Description

When `source_dir` contains `${path.module}/../src`, Terraform evaluates the path through symlinked module directories (e.g., `.terraform/modules/xxx/../src`). The `filepath.Walk` function resolves these symlinks, but `filepath.Rel` inside the walk callback compared the resolved path against the unresolved `source_dir`, causing a panic.

### Changes

Added `filepath.EvalSymlinks(indirname)` in both `ZipArchiver.ArchiveDir` and `TarArchiver.ArchiveDir` before `filepath.Walk`. This resolves the directory path to its canonical (symlink-free) form, ensuring `filepath.Rel` produces correct relative paths.

### Testing

Added `TestZipArchiver_Dir_WithSymlinkedParent` and `TestTarArchiver_Dir_WithSymlinkedParent` tests that create a symlink directory structure (mimicking Terraform module directories) and verify archiving works with `../` traversal.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.