### PR TITLE
Fix #31: Write archive to temp file and atomically rename to prevent race in checksum computation

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260727-193517.yaml
+++ b/.changes/unreleased/BUG FIXES-20260727-193517.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: 'data-source/archive_file: Fix race condition in output checksum computation by using atomic temp file writes'
+time: 2026-07-27T19:35:17.947687+02:00
+custom:
+    Issue: "31"

--- a/internal/provider/data_source_archive_file.go
+++ b/internal/provider/data_source_archive_file.go
@@ -200,7 +200,8 @@ func archive(ctx context.Context, model fileModel) error {
 	archiveType := model.Type.ValueString()
 	outputPath := model.OutputPath.ValueString()
 
-	archiver := getArchiver(archiveType, outputPath)
+	tmpPath := outputPath + ".tmp"
+	archiver := getArchiver(archiveType, tmpPath)
 	if archiver == nil {
 		return fmt.Errorf("archive type not supported: %s", archiveType)
 	}
@@ -257,6 +258,10 @@ func archive(ctx context.Context, model fileModel) error {
 		if err := archiver.ArchiveMultiple(content); err != nil {
 			return fmt.Errorf("error archiving content: %s", err)
 		}
+	}
+
+	if err := os.Rename(tmpPath, outputPath); err != nil {
+		return fmt.Errorf("error moving temporary archive to output path: %s", err)
 	}
 
 	return nil

--- a/internal/provider/zip_archiver_test.go
+++ b/internal/provider/zip_archiver_test.go
@@ -6,13 +6,36 @@ package archive
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func TestArchiveTempFileCleanup(t *testing.T) {
+	outputPath := filepath.Join(t.TempDir(), "test.zip")
+	model := fileModel{
+		Type:                  types.StringValue("zip"),
+		OutputPath:            types.StringValue(outputPath),
+		SourceContent:         types.StringValue("hello"),
+		SourceContentFilename: types.StringValue("test.txt"),
+	}
+	if err := archive(context.Background(), model); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if _, err := os.Stat(outputPath + ".tmp"); !os.IsNotExist(err) {
+		t.Fatal("expected .tmp file to be removed after archive")
+	}
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("expected output file to exist: %s", err)
+	}
+}
 
 func TestZipArchiver_Content(t *testing.T) {
 	zipFilePath := filepath.Join(t.TempDir(), "archive-content.zip")


### PR DESCRIPTION
## Related Issue

Fixes #31

## Description

When multiple `archive_file` data sources or a resource and data source share the same `output_path`, a race condition could cause `output_base64sha256` to return the hash of an empty file (`47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=`).

Root cause: the archive was written directly to `output_path`, then immediately re-read by `genFileChecksums`. A concurrent write to the same path could truncate the file between these two operations.

### Fix

The `archive()` function now writes to `outputPath + ".tmp"` and atomically renames to `outputPath` upon completion via `os.Rename`. This ensures `genFileChecksums` always reads a complete, flushed archive.

`os.Rename` is atomic on all major platforms (Linux, macOS, Windows) when replacing an existing file.

### Testing

Existing tests cover the checksum computation paths. The temp file is transparent to all callers.

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.