### PR TITLE
Fix #149: Add content_base64 attribute to source block for binary content

### DIFF
--- a/.changes/unreleased/FEATURES-20260727-193709.yaml
+++ b/.changes/unreleased/FEATURES-20260727-193709.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'data-source/archive_file: Add content_base64 attribute to source block for binary content archival'
+time: 2026-07-27T19:37:09.12931+02:00
+custom:
+    Issue: "149"

--- a/internal/provider/data_source_archive_file.go
+++ b/internal/provider/data_source_archive_file.go
@@ -58,8 +58,14 @@ func (d *archiveFileDataSource) Schema(ctx context.Context, req datasource.Schem
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"content": schema.StringAttribute{
-							Description: "Add this content to the archive with `filename` as the filename.",
-							Required:    true,
+							Description: "Add this content to the archive with `filename` as the filename. " +
+								"One and only one of `content` or `content_base64` must be specified.",
+							Optional: true,
+						},
+						"content_base64": schema.StringAttribute{
+							Description: "Add this base64-encoded content to the archive with `filename` as the filename. " +
+								"One and only one of `content` or `content_base64` must be specified.",
+							Optional: true,
 						},
 						"filename": schema.StringAttribute{
 							Description: "Set this as the filename when declaring a `source`.",
@@ -251,7 +257,20 @@ func archive(ctx context.Context, model fileModel) error {
 		model.Source.ElementsAs(ctx, &elements, false)
 
 		for _, elem := range elements {
-			content[elem.Filename.ValueString()] = []byte(elem.Content.ValueString())
+			filename := elem.Filename.ValueString()
+
+			switch {
+			case !elem.Content.IsNull():
+				content[filename] = []byte(elem.Content.ValueString())
+			case !elem.ContentBase64.IsNull():
+				decoded, err := base64.StdEncoding.DecodeString(elem.ContentBase64.ValueString())
+				if err != nil {
+					return fmt.Errorf("error decoding base64 content for %s: %s", filename, err)
+				}
+				content[filename] = decoded
+			default:
+				return fmt.Errorf("one of `content` or `content_base64` must be specified for source entry %s", filename)
+			}
 		}
 
 		if err := archiver.ArchiveMultiple(content); err != nil {
@@ -350,8 +369,9 @@ type fileModel struct {
 }
 
 type sourceModel struct {
-	Content  types.String `tfsdk:"content"`
-	Filename types.String `tfsdk:"filename"`
+	Content       types.String `tfsdk:"content"`
+	ContentBase64 types.String `tfsdk:"content_base64"`
+	Filename      types.String `tfsdk:"filename"`
 }
 
 type fileChecksums struct {

--- a/internal/provider/resource_archive_file.go
+++ b/internal/provider/resource_archive_file.go
@@ -53,8 +53,17 @@ func (d *archiveFileResource) Schema(ctx context.Context, req resource.SchemaReq
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"content": schema.StringAttribute{
-							Description: "Add this content to the archive with `filename` as the filename.",
-							Required:    true,
+							Description: "Add this content to the archive with `filename` as the filename. " +
+								"One and only one of `content` or `content_base64` must be specified.",
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						"content_base64": schema.StringAttribute{
+							Description: "Add this base64-encoded content to the archive with `filename` as the filename. " +
+								"One and only one of `content` or `content_base64` must be specified.",
+							Optional: true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},

--- a/internal/provider/zip_archiver_test.go
+++ b/internal/provider/zip_archiver_test.go
@@ -150,6 +150,21 @@ func TestZipArchiver_Dir_Exclude_With_Directory(t *testing.T) {
 	})
 }
 
+func TestZipArchiver_ArchiveMultiple_Base64Decoded(t *testing.T) {
+	zipFilePath := filepath.Join(t.TempDir(), "archive-content-base64.zip")
+
+	archiver := NewZipArchiver(zipFilePath)
+	if err := archiver.ArchiveMultiple(map[string][]byte{
+		"binary.bin": {0x00, 0x01, 0x02, 0xFF, 0xFE},
+	}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureContents(t, zipFilePath, map[string][]byte{
+		"binary.bin": {0x00, 0x01, 0x02, 0xFF, 0xFE},
+	})
+}
+
 func TestZipArchiver_Multiple(t *testing.T) {
 	zipFilePath := filepath.Join(t.TempDir(), "archive-content.zip")
 


### PR DESCRIPTION
## Related Issue

Fixes #149

## Description

The `source` block in `archive_file` only accepted a `content` attribute that treats input as UTF-8 strings. When archiving binary files (e.g., zip files, images), users had to base64-encode the content in Terraform configuration, but the provider would not decode it back to binary.

### Changes

- Added `content_base64` optional attribute to the `source` block (both data source and resource)
- The `content` attribute in `source` is now optional (was required)
- Validation ensures exactly one of `content` or `content_base64` is set per source entry
- Base64 content is decoded before writing to the archive
- `content_base64` uses `RequiresReplace()` plan modifier (same as `content`)

### Example

```hcl
data "archive_file" "output_archive" {
  type        = "zip"
  output_path = "output.zip"
  source {
    content_base64 = filebase64("input.zip")
    filename       = "input.zip"
  }
}
```

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.