### PR TITLE
Fix #59: Add file_mode attribute to source block for per-file permission control

### DIFF
--- a/.changes/unreleased/FEATURES-20260727-194113.yaml
+++ b/.changes/unreleased/FEATURES-20260727-194113.yaml
@@ -1,0 +1,5 @@
+kind: FEATURES
+body: 'data-source/archive_file: Add file_mode attribute to source block for per-file permission control'
+time: 2026-07-27T19:41:13.993645+02:00
+custom:
+    Issue: "59"

--- a/internal/provider/archiver.go
+++ b/internal/provider/archiver.go
@@ -13,11 +13,17 @@ type ArchiveDirOpts struct {
 	ExcludeSymlinkDirectories bool
 }
 
+type ArchiveFileEntry struct {
+	Content  []byte
+	FileMode string
+}
+
 type Archiver interface {
 	ArchiveContent(content []byte, infilename string) error
 	ArchiveFile(infilename string) error
 	ArchiveDir(indirname string, opts ArchiveDirOpts) error
 	ArchiveMultiple(content map[string][]byte) error
+	ArchiveMultipleEntries(entries map[string]ArchiveFileEntry) error
 	SetOutputFileMode(outputFileMode string)
 }
 

--- a/internal/provider/data_source_archive_file.go
+++ b/internal/provider/data_source_archive_file.go
@@ -65,6 +65,11 @@ func (d *archiveFileDataSource) Schema(ctx context.Context, req datasource.Schem
 							Description: "Set this as the filename when declaring a `source`.",
 							Required:    true,
 						},
+						"file_mode": schema.StringAttribute{
+							Description: "String that specifies the octal file mode for this source file. " +
+								"For example: `\"0755\"`. This overrides the `output_file_mode` for this file.",
+							Optional: true,
+						},
 					},
 				},
 				Validators: []validator.Set{
@@ -245,16 +250,23 @@ func archive(ctx context.Context, model fileModel) error {
 			return fmt.Errorf("error archiving content: %s", err)
 		}
 	case !model.Source.IsNull():
-		content := make(map[string][]byte)
+		entries := make(map[string]ArchiveFileEntry)
 
 		var elements []sourceModel
 		model.Source.ElementsAs(ctx, &elements, false)
 
 		for _, elem := range elements {
-			content[elem.Filename.ValueString()] = []byte(elem.Content.ValueString())
+			filename := elem.Filename.ValueString()
+			entry := ArchiveFileEntry{
+				Content: []byte(elem.Content.ValueString()),
+			}
+			if !elem.FileMode.IsNull() {
+				entry.FileMode = elem.FileMode.ValueString()
+			}
+			entries[filename] = entry
 		}
 
-		if err := archiver.ArchiveMultiple(content); err != nil {
+		if err := archiver.ArchiveMultipleEntries(entries); err != nil {
 			return fmt.Errorf("error archiving content: %s", err)
 		}
 	}
@@ -352,6 +364,7 @@ type fileModel struct {
 type sourceModel struct {
 	Content  types.String `tfsdk:"content"`
 	Filename types.String `tfsdk:"filename"`
+	FileMode types.String `tfsdk:"file_mode"`
 }
 
 type fileChecksums struct {

--- a/internal/provider/resource_archive_file.go
+++ b/internal/provider/resource_archive_file.go
@@ -66,6 +66,14 @@ func (d *archiveFileResource) Schema(ctx context.Context, req resource.SchemaReq
 								stringplanmodifier.RequiresReplace(),
 							},
 						},
+						"file_mode": schema.StringAttribute{
+							Description: "String that specifies the octal file mode for this source file. " +
+								"For example: `\"0755\"`. This overrides the `output_file_mode` for this file.",
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
 					},
 				},
 				Validators: []validator.Set{

--- a/internal/provider/tar_archiver.go
+++ b/internal/provider/tar_archiver.go
@@ -185,28 +185,45 @@ func (a *TarArchiver) createWalkFunc(basePath, indirname string, opts ArchiveDir
 }
 
 func (a *TarArchiver) ArchiveMultiple(content map[string][]byte) error {
+	entries := make(map[string]ArchiveFileEntry, len(content))
+	for k, v := range content {
+		entries[k] = ArchiveFileEntry{Content: v}
+	}
+	return a.ArchiveMultipleEntries(entries)
+}
+
+func (a *TarArchiver) ArchiveMultipleEntries(entries map[string]ArchiveFileEntry) error {
 	if err := a.open(); err != nil {
 		return err
 	}
 	defer a.close()
 
 	// Ensure files are processed in the same order so hashes don't change
-	keys := make([]string, len(content))
+	keys := make([]string, len(entries))
 	i := 0
-	for k := range content {
+	for k := range entries {
 		keys[i] = k
 		i++
 	}
 	sort.Strings(keys)
 
 	for _, filename := range keys {
+		entry := entries[filename]
 		header := &tar.Header{
 			Name:    filepath.ToSlash(filename),
-			Size:    int64(len(content[filename])),
+			Size:    int64(len(entry.Content)),
 			ModTime: time.Time{},
 		}
 
-		if err := a.addContent(content[filename], header); err != nil {
+		if entry.FileMode != "" {
+			filemode, parseErr := strconv.ParseInt(entry.FileMode, 0, 32)
+			if parseErr != nil {
+				return fmt.Errorf("error parsing file_mode value: %s", entry.FileMode)
+			}
+			header.Mode = filemode
+		}
+
+		if err := a.addContent(entry.Content, header); err != nil {
 			return err
 		}
 	}

--- a/internal/provider/zip_archiver.go
+++ b/internal/provider/zip_archiver.go
@@ -6,6 +6,7 @@ package archive
 import (
 	"archive/zip"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -224,26 +225,57 @@ func (a *ZipArchiver) createWalkFunc(basePath, indirname string, opts ArchiveDir
 }
 
 func (a *ZipArchiver) ArchiveMultiple(content map[string][]byte) error {
+	entries := make(map[string]ArchiveFileEntry, len(content))
+	for k, v := range content {
+		entries[k] = ArchiveFileEntry{Content: v}
+	}
+	return a.ArchiveMultipleEntries(entries)
+}
+
+func (a *ZipArchiver) ArchiveMultipleEntries(entries map[string]ArchiveFileEntry) error {
 	if err := a.open(); err != nil {
 		return err
 	}
 	defer a.close()
 
 	// Ensure files are processed in the same order so hashes don't change
-	keys := make([]string, len(content))
+	keys := make([]string, len(entries))
 	i := 0
-	for k := range content {
+	for k := range entries {
 		keys[i] = k
 		i++
 	}
 	sort.Strings(keys)
 
 	for _, filename := range keys {
-		f, err := a.writer.Create(filepath.ToSlash(filename))
+		entry := entries[filename]
+		content := entry.Content
+		fileMode := entry.FileMode
+
+		var f io.Writer
+		var err error
+
+		if fileMode != "" {
+			filemode, parseErr := strconv.ParseUint(fileMode, 0, 32)
+			if parseErr != nil {
+				return fmt.Errorf("error parsing file_mode value: %s", fileMode)
+			}
+			fh := &zip.FileHeader{
+				Name:   filepath.ToSlash(filename),
+				Method: zip.Deflate,
+			}
+			fh.SetMode(os.FileMode(filemode))
+			//nolint:staticcheck
+			fh.SetModTime(time.Time{})
+			f, err = a.writer.CreateHeader(fh)
+		} else {
+			f, err = a.writer.Create(filepath.ToSlash(filename))
+		}
+
 		if err != nil {
 			return err
 		}
-		_, err = f.Write(content[filename])
+		_, err = f.Write(content)
 		if err != nil {
 			return err
 		}

--- a/internal/provider/zip_archiver_test.go
+++ b/internal/provider/zip_archiver_test.go
@@ -150,6 +150,22 @@ func TestZipArchiver_Dir_Exclude_With_Directory(t *testing.T) {
 	})
 }
 
+func TestZipArchiver_Multiple_WithFileMode(t *testing.T) {
+	zipFilePath := filepath.Join(t.TempDir(), "archive-multiple-filemode.zip")
+
+	archiver := NewZipArchiver(zipFilePath)
+	if err := archiver.ArchiveMultipleEntries(map[string]ArchiveFileEntry{
+		"script.sh": {Content: []byte("#!/bin/sh\necho hi"), FileMode: "0755"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	ensureContents(t, zipFilePath, map[string][]byte{
+		"script.sh": []byte("#!/bin/sh\necho hi"),
+	})
+	ensureFileMode(t, zipFilePath, "0755")
+}
+
 func TestZipArchiver_Multiple(t *testing.T) {
 	zipFilePath := filepath.Join(t.TempDir(), "archive-content.zip")
 


### PR DESCRIPTION
## Related Issue

Fixes #59

## Description

The `output_file_mode` attribute applies a single mode to all files in the archive, but users need per-file permissions (e.g., `0755` for Lambda executables, `0644` for config files).

### Changes

- Added `file_mode` optional attribute to the `source` block (both data source and resource)
- Added `ArchiveFileEntry` struct and `ArchiveMultipleEntries` method to the `Archiver` interface
- Implemented per-file mode in both `ZipArchiver` and `TarArchiver`
- The existing `ArchiveMultiple` method delegates to `ArchiveMultipleEntries` for backward compatibility
- `file_mode` overrides `output_file_mode` for individual files

### Example

```hcl
data "archive_file" "lambda" {
  type        = "zip"
  output_path = "lambda.zip"
  source {
    content   = data.http.datadog.body
    filename  = "lambda_function.py"
    file_mode = "0755"
  }
}
```

### Backward Compatibility

This change is fully backward compatible. Existing configurations that do not set `file_mode` continue to work with default permissions (0644 for source blocks).

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.